### PR TITLE
[fix] Исправлен checkout в workflow Fastlane для корректной работы Danger

### DIFF
--- a/.github/workflows/build-for-pr.yml
+++ b/.github/workflows/build-for-pr.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION

> Что сделано:

- Исправлена конфигурация actions/checkout в workflow Fastlane
- Добавлен параметр fetch-depth: 0 для загрузки полной git history

> Проблема:

- Danger падал с ошибкой:
Cannot find a merge base between danger_base and danger_head
- Не строился diff между develop и PR-веткой

> Решение:

- Добавлен fetch-depth: 0, что позволяет:
  -  получить полную историю коммитов
  -   найти общий commit (merge base)
  -  корректно построить diff PR

> Результат:

- Danger корректно выполняет проверки PR
- CI больше не падает на этапе анализа изменений