### PR TITLE
[SW-5] - Добавил переиспользуемый TextField

### DIFF
--- a/Swaply/Assets.xcassets/Colors/Tertiary.colorset/Contents.json
+++ b/Swaply/Assets.xcassets/Colors/Tertiary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.118",
+          "green" : "0.118",
+          "red" : "0.118"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swaply/DesignSystem/AppColors.swift
+++ b/Swaply/DesignSystem/AppColors.swift
@@ -15,6 +15,7 @@ enum AppColors {
     // Background Colors
     static let backgroundPrimary = UIColor(resource: .black900)
     static let backgroundSecondary = UIColor(resource: .secondaryBg)
+    static let backgroundTertiary = UIColor(resource: .tertiary)
     // Accent Color
     static let accentColor = UIColor(resource: .accent)
     // Gradient Color

--- a/Swaply/UI Components/TextField/CustomTextField.swift
+++ b/Swaply/UI Components/TextField/CustomTextField.swift
@@ -1,0 +1,88 @@
+//
+//  CustomTextField.swift
+//  Swaply
+//
+//  Created by Владислав Абушенко on 9.04.2026.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+
+final class CustomTextField: UIView {
+
+    // MARK: - Public Properties
+    var textObservable: Observable<String> {
+        textSubject
+    }
+
+    // MARK: - Private Properties
+    private let textSubject = PublishSubject<String>()
+    private let textField = UITextField()
+
+    // MARK: - Initializers
+    init(placeholder: String) {
+        super.init(frame: .zero)
+        setupUI()
+        setupConstraints()
+        setupActions()
+        setupPlaceholder(placeholder)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { nil }
+
+    // MARK: - Public Methods
+    func setText(_ text: String) {
+        textField.text = text
+    }
+
+    func getText() -> String {
+        textField.text ?? ""
+    }
+
+    // MARK: - Private Methods
+    private func setupUI() {
+        textField.borderStyle = .none
+        textField.backgroundColor = AppColors.backgroundTertiary
+        textField.layer.cornerRadius = AppRadius.medium
+        textField.tintColor = AppColors.buttonWithImPressed
+
+        textField.leftView = makePadding(AppSpacing.medium)
+        textField.leftViewMode = .always
+        textField.rightView = makePadding(AppSpacing.medium)
+        textField.rightViewMode = .always
+
+        textField.font = AppTypography.body
+        textField.textColor = AppColors.white
+
+        addSubview(textField)
+    }
+
+    private func setupConstraints() {
+        textField.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+
+    private func setupActions() {
+        textField.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            textSubject.onNext(textField.text ?? "")
+        }, for: .editingChanged)
+    }
+
+    private func setupPlaceholder(_ text: String) {
+        textField.attributedPlaceholder = NSAttributedString(
+            string: text,
+            attributes: [
+                .foregroundColor: AppColors.grey400,
+                .font: AppTypography.body
+            ]
+        )
+    }
+
+    private func makePadding(_ width: CGFloat) -> UIView {
+        UIView(frame: CGRect(x: 0, y: 0, width: width, height: 1))
+    }
+}

--- a/Swaply/UI Components/TextField/CustomTextField.swift
+++ b/Swaply/UI Components/TextField/CustomTextField.swift
@@ -40,9 +40,12 @@ final class CustomTextField: UIView {
     func getText() -> String {
         textField.text ?? ""
     }
+}
+
+extension CustomTextField {
 
     // MARK: - Private Methods
-    private func setupUI() {
+    func setupUI() {
         textField.borderStyle = .none
         textField.backgroundColor = AppColors.backgroundTertiary
         textField.layer.cornerRadius = AppRadius.medium
@@ -59,20 +62,24 @@ final class CustomTextField: UIView {
         addSubview(textField)
     }
 
-    private func setupConstraints() {
+    func setupConstraints() {
         textField.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
     }
 
-    private func setupActions() {
-        textField.addAction(UIAction { [weak self] _ in
+    func setupActions() {
+        textField.addAction(
+            UIAction {
+                [weak self] _ in
             guard let self else { return }
             textSubject.onNext(textField.text ?? "")
-        }, for: .editingChanged)
+        },
+            for: .editingChanged
+        )
     }
 
-    private func setupPlaceholder(_ text: String) {
+    func setupPlaceholder(_ text: String) {
         textField.attributedPlaceholder = NSAttributedString(
             string: text,
             attributes: [
@@ -82,7 +89,7 @@ final class CustomTextField: UIView {
         )
     }
 
-    private func makePadding(_ width: CGFloat) -> UIView {
+    func makePadding(_ width: CGFloat) -> UIView {
         UIView(frame: CGRect(x: 0, y: 0, width: width, height: 1))
     }
 }


### PR DESCRIPTION
### **Что сделано:**
- Реализован переиспользуемый UI-компонент TextField
- Выполнена верстка кастомного TextField
- Добавлена настройка placeholder при инициализации

### **Технические детали:**
- Добавлены публичные методы для ручного управления текстом в поле:
  -  setText – для ручной подстановки текста
  -  getText – для ручного получения текущего значения
- Добавлен textObservable для отслеживания изменений текста в реальном времени

### **Как использовать:**

Пример создания TextField и подписки на изменения в нем:

```swift
let textField = CustomTextField(placeholder: "Имя")

textField.textObservable
    .subscribe(onNext: { text in
        print(text)
    })
    .disposed(by: disposeBag)
```
### **Скриншоты:**

![TextField](https://github.com/user-attachments/assets/0818f826-0d8c-47cd-b46c-5a9ca9d3ce80)

### **Связанные задачи:**
SW-5 (https://github.com/Swaply-masterskaya/ios/issues/5)

